### PR TITLE
Generalize profile picture code for map and member pages

### DIFF
--- a/_includes/members.js
+++ b/_includes/members.js
@@ -1,25 +1,32 @@
-var otnMembers = [
+var memberImageSrc = {};
+var otnMembers = [];
+var img_src = "";
+
 {% for member in site.members %}
+          {% assign static_image_expected = member.id | prepend: '/images' | append: '.jpg' %}
+          {% assign static_image_found = null %}
+          {% for static_file in site.static_files %}
+            {% if static_file.path contains static_image_expected %}
+              {% assign static_image_found = static_file.path %}
+            {% endif %}
+          {% endfor %}
+          {% if member.image %}
+            img_src = "{{ member.image }}",
+          {% elsif static_image_found %}
+            img_src = "{{ static_image_found }}",
+          {% elsif member.github %}
+            img_src = "https://github.com/{{ member.github }}.png?size=200",
+          {% else %}
+            img_src = "",
+          {% endif %}
+    memberImageSrc["{{member.id}}"] = img_src;
   {% if member.lat and member.long %}
-    {
+    otnMembers.push({
       "type": "Feature",
       "properties": {
         "name": "{{ member.name }}",
         "popupContent": "\
-          {% assign static_image_expected = member.id | prepend: '/images' | append: '.jpg' %}\
-          {% assign static_image_found = null %}\
-          {% for static_file in site.static_files %}\
-            {% if static_file.path contains static_image_expected %}\
-              {% assign static_image_found = static_file.path %}\
-            {% endif %}\
-          {% endfor %}\
-          {% if member.image %}\
-  	        <img src='{{ member.image }}' width='60px'>\
-          {% elsif static_image_found %}\
-  	        <img src='{{ static_image_found }}' width='60px'>\
-          {% elsif member.github %}\
-            <img src='https://github.com/{{ member.github }}.png?size=60'>\
-          {% endif %}\
+	  <img src='"+img_src+"' width='60px'>\
           <br><a href='{{ member.id }}'>{{ member.name }}</a>,\
           {{ member.affiliation }}\
          "
@@ -28,7 +35,7 @@ var otnMembers = [
         "type": "Point",
         "coordinates": [{{ member.long }}, {{ member.lat }}]
       }
-    },
+    });
   {% endif %}
 {% endfor %}
-];
+

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -9,7 +9,7 @@ layout: default
 
   <div class="post-content">
     <table>
-      <tr><td><img src="/images/{{ page.id }}.jpg" width="200px" /></td>
+      <tr><td><img src="" width="200px" id="profileImage" /></td>
         <td>
           <p>{{ page.affiliation }}</p>
           <p><a href="mailto:{{ page.email }}">{{ page.email }}</a></p>
@@ -21,5 +21,13 @@ layout: default
     </table>    
     <!-- <em>{{ content }}</em> -->
   </div>
+
+  <script type="text/javascript">
+    {% include members.js %}
+    document.addEventListener("DOMContentLoaded", function(event) {
+      element = document.getElementById("profileImage");
+      element.src = memberImageSrc["{{page.id}}"];
+    });
+  </script>
 
 </article>


### PR DESCRIPTION
Probably not the most elegant solution but the same image is selected for the map and profile page now. The first match is used:
 - `image` tag from the yml header
 - image in `images/members/id` directory
 - profile picture of `github` account from yml header
 - empty - a broken image is displayed, we should probably replace that with a generic anonymous picture, something like this: ![Blank Profile Picture](https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png)

Related to #25 